### PR TITLE
Use look-up-table and threading for major speed improvements

### DIFF
--- a/netbox_dnsmasq.py
+++ b/netbox_dnsmasq.py
@@ -148,7 +148,8 @@ def get_ip_data(
     dhcp_prefixes = nb.ipam.prefixes.filter(tag=[dhcp_tag])
     ip_addresses = nb.ipam.ip_addresses.filter(tag=[dhcp_ignore_tag])
 
-    # create cache for dcim.interfaces as looking up mac addresses within loop is quite slow
+    # create cache for dcim.interfaces as looking up mac addresses within
+    # loop is quite slow
     interface_cache = {}
     for iface in nb.dcim.interfaces.all():
         interface_cache[iface.id] = iface

--- a/netbox_dnsmasq.py
+++ b/netbox_dnsmasq.py
@@ -1,5 +1,8 @@
+#!/usr/bin/env python3
+# noqa: E265
+
 """Main script for netbox_dnsmasq."""
-# !/usr/bin/env python3 # noqa: E265
+
 from __future__ import annotations
 
 import argparse

--- a/netbox_dnsmasq.py
+++ b/netbox_dnsmasq.py
@@ -147,6 +147,12 @@ def get_ip_data(
     nb_dns = {}
     dhcp_prefixes = nb.ipam.prefixes.filter(tag=[dhcp_tag])
     ip_addresses = nb.ipam.ip_addresses.filter(tag=[dhcp_ignore_tag])
+
+    # create cache for dcim.interfaces as looking up mac addresses within loop is quite slow
+    interface_cache = {}
+    for iface in nb.dcim.interfaces.all():
+        interface_cache[iface.id] = iface
+
     for ip in ip_addresses:
         ip_address = re.sub("/.*", "", ip.address)
         if len(ip.dns_name) > 0:
@@ -170,11 +176,13 @@ def get_ip_data(
         for ip in prefix_ips:
             ip_address = re.sub("/.*", "", ip.address)
             if ip.assigned_object_id:
+                mac_address = interface_cache[ip.assigned_object_id].mac_address \
+                    if ip.assigned_object_id in interface_cache else ip.assigned_object.mac_address
                 if (
-                    ip.assigned_object.mac_address is not None
+                    mac_address is not None
                     and dhcp_ignore_tag not in list(t.name for t in ip.tags)
                 ):
-                    mac = ip.assigned_object.mac_address.lower()
+                    mac = mac_address.lower()
                     if ip_address in nb_dhcp:
                         logger.warning(
                             f"Duplicate IP address {ip_address}"

--- a/netbox_dnsmasq.py
+++ b/netbox_dnsmasq.py
@@ -176,11 +176,13 @@ def get_ip_data(
         for ip in prefix_ips:
             ip_address = re.sub("/.*", "", ip.address)
             if ip.assigned_object_id:
-                mac_address = interface_cache[ip.assigned_object_id].mac_address \
-                    if ip.assigned_object_id in interface_cache else ip.assigned_object.mac_address
-                if (
-                    mac_address is not None
-                    and dhcp_ignore_tag not in list(t.name for t in ip.tags)
+                mac_address = (
+                    interface_cache[ip.assigned_object_id].mac_address
+                    if ip.assigned_object_id in interface_cache
+                    else ip.assigned_object.mac_address
+                )
+                if mac_address is not None and dhcp_ignore_tag not in list(
+                    t.name for t in ip.tags
                 ):
                     mac = mac_address.lower()
                     if ip_address in nb_dhcp:

--- a/netbox_dnsmasq.py
+++ b/netbox_dnsmasq.py
@@ -351,7 +351,7 @@ def main() -> None:
         DNS_hosts_location,
     ) = import_config(args.dev)
 
-    api = pynetbox.api(url=NETBOX_ENDPOINT, token=NETBOX_TOKEN)
+    api = pynetbox.api(url=NETBOX_ENDPOINT, token=NETBOX_TOKEN, threading=True)
 
     dhcp, dns = get_ip_data(args.dns_tag, args.tag, nb=api)
     check_duplicates(


### PR DESCRIPTION
Currently, our netbox instance holds more than 3000 devices and more than 10k interfaces and IPs and creating an updated set of configuration files took more than 10 minutes.

The root problem seemed to be the API call to get the MAC address of the associated interfaces within the `prefix` loop. Adding a look-up-table greatly reduced run time to about 80s. Adding threading to the API instantiation got us another factor of 2 in speed-up.

(I hope this PR is good enough, I rarely do these on github. And sorry that unrelated commit 375d41e is also in here - I needed that to be able to call the script directly (`./netbox_dnsmasq.py`) - if you disagree with that one, I can try removing it) 